### PR TITLE
Reader now works with basic syntax

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
+# Build
 dist/
+
+# Stack
+.stack-work/

--- a/examples/factorial.k
+++ b/examples/factorial.k
@@ -1,0 +1,5 @@
+(:: factorial Int Int)
+(defn factorial [n]
+  (if (= n 0)
+    1
+    (* n (factorial (dec n)))))

--- a/kriek.cabal
+++ b/kriek.cabal
@@ -39,21 +39,21 @@ library
   default-language:    Haskell2010
 
 executable kriek
-  hs-source-dirs:      .
+  hs-source-dirs:      src/
   main-is:             Main.hs
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   build-depends:       base
                      , kriek
   default-language:    Haskell2010
 
-test-suite kriek-test
-  type:                exitcode-stdio-1.0
-  hs-source-dirs:      test
-  main-is:             Spec.hs
-  build-depends:       base
-                     , kriek
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
-  default-language:    Haskell2010
+-- test-suite kriek-test
+--   type:                exitcode-stdio-1.0
+--   hs-source-dirs:      test
+--   main-is:             Spec.hs
+--   build-depends:       base
+--                      , kriek
+--   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+--   default-language:    Haskell2010
 
 source-repository head
   type:     git

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,0 +1,5 @@
+import Kriek.Repl (repl)
+import Kriek.Runtime.Data
+
+main :: IO ()
+main = repl newState

--- a/src/hs/Kriek/Ast.hs
+++ b/src/hs/Kriek/Ast.hs
@@ -14,11 +14,11 @@ newtype Name = Name String
 data Position = Position { filename :: String, line :: Word, col :: Word }
   deriving (Eq, Generic, Hashable)
 
-data Form a = Form (AST a) (Maybe Position) (Maybe (Meta a))
+data Form a = Form (AST a) (Maybe Position) -- (Maybe (Meta a))
   deriving (Generic, Hashable)
 
 instance Eq a => Eq (Form a) where
-  (Form a _ _) == (Form b _ _) = a == b
+  (Form a _) == (Form b _) = a == b
 
 type RecItem a = ((Name, Maybe Position), Form a)
 
@@ -37,19 +37,19 @@ data AST a
   deriving (Eq, Generic, Hashable)
 
 instance Show a => Show (Form a) where
-  show (Form a _ _) = show a
+  show (Form a _) = show a
 
 instance Show a => Show (AST a) where
   show KNil = "nil"
   show (KInt i) = show i
   show (KFloat  f) = show f
   show (KChar   c) = show c
-  show (KString s) = s
+  show (KString s) = "\"" ++ s ++ "\""
   show (KSymbol  (Name n)) = n
   show (KKeyword (Name n)) = ':':n
-  show (KList    l) = "(" ++ (intercalate "," (fmap show l)) ++ ")"
-  show (KTuple   l) = "[" ++ (intercalate "," (fmap show l)) ++ "]"
-  show (KRecord  l) = "{" ++ (intercalate "," (fmap h l)) ++"}"
-    where h (((Name k),_),(Form v _ _)) = ':':k ++ ' ':(show v)
+  show (KList    l) = "(" ++ (intercalate ", " (fmap show l)) ++ ")"
+  show (KTuple   l) = "[" ++ (intercalate ", " (fmap show l)) ++ "]"
+  show (KRecord  l) = "{" ++ (intercalate ", " (fmap h l)) ++"}"
+    where h (((Name k),_),(Form v _)) = ':':k ++ ' ':(show v)
   show (KRuntime a) = show a
 

--- a/src/hs/Kriek/Reader.hs
+++ b/src/hs/Kriek/Reader.hs
@@ -34,13 +34,8 @@ spToPos (SourcePos n l c) = Position n (unPos l) (unPos c)
 sourcePos :: Parser Position
 sourcePos = (spToPos . LNE.head . statePos) `liftM` getParserState
 
--- FIXME: different case
 kComment :: Parser ()
-kComment = do _ <- char ';' <?> "comment marker"
-              _ <- many (satisfy h) <?> ""
-              _ <- char '\n'
-              return ()
-  where h x = fromEnum x > 0x7f
+kComment = L.skipLineComment ";"
 
 kBareSym :: Parser (AST a)
 kBareSym = do s <- oneOf start <?> "symbol start character"

--- a/src/hs/Kriek/Reader.hs
+++ b/src/hs/Kriek/Reader.hs
@@ -68,10 +68,8 @@ kNum = do n <- L.signed (return ()) L.number
                       then KInt (coefficient n)
                       else KFloat n
 
--- TODO: Handle escapes
 kString :: Parser (AST a)
-kString = KString <$> between (char '"') (char '"') str
-  where str = many (noneOf "\"")
+kString = KString <$> (char '"' >> manyTill L.charLiteral (char '"'))
 
 kChar :: Parser (AST a)
 kChar = string "#\\" >> KChar <$> L.charLiteral

--- a/src/hs/Kriek/Reader.hs
+++ b/src/hs/Kriek/Reader.hs
@@ -52,7 +52,7 @@ kBareSym = do s <- oneOf start <?> "symbol start character"
 kQSym :: Parser (AST a)
 kQSym = between (char '|') (char '|') h
   where h = (KSymbol . Name) <$> some (noneOf banned)
-        banned = " |\n" ++ forbidden
+        banned = "|\n" ++ forbidden
 
 kKeyword :: Parser (AST a)
 kKeyword = do _ <- char ':'
@@ -77,8 +77,7 @@ kChar :: Parser (AST a)
 kChar = string "#\\" >> KChar <$> L.charLiteral
 
 kListy :: (Char, Char) -> Parser [Form a]
-kListy (s,e) =
-  between (char s) (char e) h
+kListy (s,e) = between (char s) (char e) h
   where h = trim $ sepBy form space
 
 kList :: Parser (AST a)

--- a/src/hs/Kriek/Reader.hs
+++ b/src/hs/Kriek/Reader.hs
@@ -49,11 +49,10 @@ kBareSym = do s <- oneOf start <?> "symbol start character"
   where start = "abcdefghijklmnopqrstuvwxyz"
         rest = start ++ ""
 
--- FIXME
 kQSym :: Parser (AST a)
 kQSym = between (char '|') (char '|') h
   where h = (KSymbol . Name) <$> some (noneOf banned)
-        banned = "|\n" ++ forbidden
+        banned = " |\n" ++ forbidden
 
 kKeyword :: Parser (AST a)
 kKeyword = do _ <- char ':'
@@ -69,9 +68,10 @@ kNum = do n <- L.signed (return ()) L.number
                       then KInt (coefficient n)
                       else KFloat n
 
--- FIXME
+-- TODO: Handle escapes
 kString :: Parser (AST a)
-kString = KString <$> between (char '"') (char '"') (many L.charLiteral)
+kString = KString <$> between (char '"') (char '"') str
+  where str = many (noneOf "\"")
 
 kChar :: Parser (AST a)
 kChar = string "#\\" >> KChar <$> L.charLiteral
@@ -81,11 +81,9 @@ kListy (s,e) =
   between (char s) (char e) h
   where h = trim $ sepBy form space
 
--- FIXME
 kList :: Parser (AST a)
 kList = KList <$> kListy ('(',')')
 
--- FIXME
 kTuple :: Parser (AST a)
 kTuple = KTuple <$> kListy ('[',']')
 

--- a/src/hs/Kriek/Repl.hs
+++ b/src/hs/Kriek/Repl.hs
@@ -20,8 +20,10 @@ read :: IO [Form a]
 read = do
     flushStr prompt
     input <- getLine
-    case parse program "" input of
-        Left e -> error $ parseErrorPretty e
+    case parse program "" (input ++ "\n") of
+        Left e -> do
+          putStrLn $ parseErrorPretty e
+          return []
         Right x -> return x
 
 eval :: [Form RT] -> Runtime [Form RT]

--- a/src/hs/Kriek/Repl.hs
+++ b/src/hs/Kriek/Repl.hs
@@ -20,7 +20,7 @@ read :: IO [Form a]
 read = do
     flushStr prompt
     input <- getLine
-    case parse program "" (input ++ "\n") of
+    case parse program "" input of
         Left e -> do
           putStrLn $ parseErrorPretty e
           return []


### PR DESCRIPTION
`Meta` has been removed for the time being.

You'll also notice I re-added the stuff in `kriek.cabal` under `executable`. You have the folder `src/hs` specified as a library, even though `src/hs/Kriek.hs` exports a `main` function. Either we change `src/hs` to a binary or we leave it as `src/Main.hs`. I prefer the first option. 