### PR TITLE
Fixed REPL and cabal config

### DIFF
--- a/kriek.cabal
+++ b/kriek.cabal
@@ -39,7 +39,7 @@ library
   default-language:    Haskell2010
 
 executable kriek
-  hs-source-dirs:      src/
+  hs-source-dirs:      .
   main-is:             Main.hs
   ghc-options:         -threaded -rtsopts -with-rtsopts=-N
   build-depends:       base

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,5 +1,0 @@
-import Kriek.Repl (repl)
-import Kriek.Runtime.Data
-
-main :: IO ()
-main = repl newState

--- a/src/hs/Kriek/Ast.hs
+++ b/src/hs/Kriek/Ast.hs
@@ -49,12 +49,12 @@ instance Show AST where
   show (AInt i) = show i
   show (AFloat  f) = show f
   show (AChar   c) = show c
-  show (AString s) = s
+  show (AString s) = "\"" ++ s ++ "\""
   show (ASymbol  n) = show n
   show (AKeyword n) = ':':(show n)
-  show (AList    l) = "(" ++ (intercalate "," (fmap show l)) ++ ")"
-  show (ATuple   l) = "[" ++ (intercalate "," (fmap show l)) ++ "]"
-  show (ARecord  l) = "{" ++ (intercalate "," (fmap h l)) ++"}"
+  show (AList    l) = "(" ++ (intercalate ", " (fmap show l)) ++ ")"
+  show (ATuple   l) = "[" ++ (intercalate ", " (fmap show l)) ++ "]"
+  show (ARecord  l) = "{" ++ (intercalate ", " (fmap h l)) ++"}"
     where h ((Form k _),(Form v _)) = (show k) ++ ' ':(show v)
 
 

--- a/src/hs/Kriek/Repl.hs
+++ b/src/hs/Kriek/Repl.hs
@@ -16,7 +16,7 @@ flushStr str = putStr str >> hFlush stdout
 prompt :: String
 prompt = "kriek> "
 
-read :: IO [Form a]
+read :: IO [Form]
 read = do
     flushStr prompt
     input <- getLine
@@ -26,10 +26,10 @@ read = do
           return []
         Right x -> return x
 
-eval :: State -> [Form RT] -> IO (State, [Form RT])
+eval :: State -> [Form] -> IO (State, [Form])
 eval s f = return (s,f) -- runStateT
 
-print :: [Form RT] -> IO ()
+print :: [Form] -> IO ()
 print = putStrLn . show
 
 repl :: State -> IO ()


### PR DESCRIPTION
Changed cabal config to use `./Main.hs` as a shim for `src/hs/Kriek.hs`.

I also found that the types used in `Kriek.Repl` weren't deparameterised, so I updated those.