### PR TITLE
Added simple command line parsing and simple compiler API

### DIFF
--- a/kriek.cabal
+++ b/kriek.cabal
@@ -17,6 +17,7 @@ library
   hs-source-dirs:      src/hs
   exposed-modules:     Kriek
                      , Kriek.Ast
+                     , Kriek.Compiler
                      , Kriek.Reader
                      , Kriek.Repl
                      , Kriek.Runtime

--- a/kriek.cabal
+++ b/kriek.cabal
@@ -1,6 +1,6 @@
 name:                kriek
 version:             0.1.0.0
-synopsis:            A low level systems programming lisp
+synopsis:            A statically typed lisp-like language
 description:         Please see README.md
 homepage:            https://github.com/jjl/kriek
 license:             BSD3

--- a/kriek.cabal
+++ b/kriek.cabal
@@ -32,6 +32,7 @@ library
                      , language-javascript
                      , parsers
                      , megaparsec
+                     , cmdargs
                      -- , text-icu
                      , mtl
                      , transformers

--- a/src/hs/Kriek.hs
+++ b/src/hs/Kriek.hs
@@ -1,7 +1,26 @@
+{-# LANGUAGE DeriveDataTypeable #-}
 module Kriek where
 
-import Kriek.Repl (repl)
-import Kriek.Runtime.Data
+import qualified Kriek.Compiler as C
+import qualified Kriek.Repl as R
+import Kriek.Runtime.Data (newState)
+import System.Console.CmdArgs
+
+data KriekCmd = Repl
+              | Compile { src :: FilePath, out :: FilePath }
+              deriving (Data, Typeable)
+
+repl :: KriekCmd
+repl = Repl
+
+compile :: KriekCmd
+compile = Compile
+  { src = def &= argPos 0 &= typ "SRC"
+  , out = def &= argPos 1 &= typ "OUT"}
 
 main :: IO ()
-main = repl newState
+main = do
+  args <- cmdArgs (modes [repl, compile])
+  case args of
+    Repl -> R.repl newState
+    Compile src out -> C.compileFile src out

--- a/src/hs/Kriek.hs
+++ b/src/hs/Kriek.hs
@@ -18,9 +18,15 @@ compile = Compile
   { src = def &= argPos 0 &= typ "SRC"
   , out = def &= argPos 1 &= typ "OUT"}
 
+
+mode = cmdArgsMode $ modes [repl, compile]
+  &= program "kriek"
+  &= summary "Kriek v0.1"
+  &= help "A statically typed lisp-like language"
+
 main :: IO ()
 main = do
-  args <- cmdArgs (modes [repl, compile])
+  args <- cmdArgsRun mode
   case args of
     Repl -> R.repl newState
     Compile src out -> C.compileFile src out

--- a/src/hs/Kriek.hs
+++ b/src/hs/Kriek.hs
@@ -19,7 +19,7 @@ compile = Compile
   , out = def &= argPos 1 &= typ "OUT"}
 
 
-mode = cmdArgsMode $ modes [repl, compile]
+mode = cmdArgsMode $ modes [repl, compile &= auto]
   &= program "kriek"
   &= summary "Kriek v0.1"
   &= help "A statically typed lisp-like language"

--- a/src/hs/Kriek/Compiler.hs
+++ b/src/hs/Kriek/Compiler.hs
@@ -1,0 +1,20 @@
+module Kriek.Compiler (compile, compileFile) where
+
+import Kriek.Reader (program)
+import Text.Megaparsec (parse, parseErrorPretty)
+import Data.Maybe
+
+-- Accepts an optional file path of the file being compiled.
+--
+-- TODO: Don't use strings
+compile :: Maybe FilePath -> String -> String
+compile path s = case parse program p s of
+                   Left e -> error $ parseErrorPretty e
+                   Right x -> show x
+  where p = fromMaybe "" path
+
+-- Compile file from `src` and store the output in `out`.
+compileFile :: FilePath -> FilePath -> IO ()
+compileFile src out = do
+  contents <- readFile src
+  writeFile out $ compile (Just src) contents


### PR DESCRIPTION
Added a command line interface.

`kriek repl` -- as the name suggests, runs a REPL
`kriek compile SRC OUT` -- compiles file SRC to file OUT. Currently only outputs the read AST

As for `Kriek.Compiler`, its just the start of what I imagine the high-level API will look like. I wasn't sure about the behaviour of `compileFile`, should it be `FilePath -> IO String` or `FilePath -> FilePath -> IO ()`? I chose the latter because it made it easier to work with when defining the command line API.