### PR TITLE
Fixed meta parser

### DIFF
--- a/src/hs/Kriek/Ast.hs
+++ b/src/hs/Kriek/Ast.hs
@@ -53,7 +53,5 @@ instance Show AST where
   show (AKeyword n) = ':':(show n)
   show (AList    l) = "(" ++ (intercalate ", " (fmap show l)) ++ ")"
   show (ATuple   l) = "[" ++ (intercalate ", " (fmap show l)) ++ "]"
-  show (ARecord  l) = "{" ++ (intercalate ", " (fmap h l)) ++"}"
+  show (ARecord  l) = "{" ++ (intercalate ", " (fmap h l)) ++ "}"
     where h ((Form k _ _),(Form v _ _)) = (show k) ++ ' ':(show v)
-
-

--- a/src/hs/Kriek/Compiler.hs
+++ b/src/hs/Kriek/Compiler.hs
@@ -11,7 +11,7 @@ compile :: Maybe FilePath -> String -> String
 compile path s = case parse program p s of
                    Left e -> error $ parseErrorPretty e
                    Right x -> show x
-  where p = fromMaybe "" path
+  where p = fromMaybe "(unknown)" path
 
 -- Compile file from `src` and store the output in `out`.
 compileFile :: FilePath -> FilePath -> IO ()

--- a/src/hs/Kriek/Ir.hs
+++ b/src/hs/Kriek/Ir.hs
@@ -7,7 +7,7 @@ import Control.Monad.Except
 import qualified Data.HashMap.Strict as M
 import Kriek.Ast
 
-type Fn = [Form] -> Runtime (Form)
+type Fn = [Form] -> Runtime Form
 
 type NamedForm = (String, Form)
 
@@ -42,5 +42,3 @@ data State = State
 
 newState :: State
 newState = State [] M.empty M.empty
-
-    

--- a/src/hs/Kriek/Reader.hs
+++ b/src/hs/Kriek/Reader.hs
@@ -99,8 +99,8 @@ kAst = kQSym <|> kList <|> kTuple <|> kString <|> kKeyword <|> kChar <|> kNil <|
 
 form :: Parser Form
 form = do p <- sourcePos
-          m <- optional kMeta <* many ws
-          o <- kAst
+          m <- many ws *> optional kMeta
+          o <- many ws *> kAst
           return $ Form o (Just p) m
 
 program :: Parser [Form]

--- a/src/hs/Kriek/Reader.hs
+++ b/src/hs/Kriek/Reader.hs
@@ -19,9 +19,6 @@ wsc = many (ws <|> kComment) >> return ()
 mwsc :: Parser ()
 mwsc = some (ws <|> kComment) >> return ()
 
-wscSep :: Parser a -> Parser [a]
-wscSep a = sepBy a mwsc
-
 trim :: Parser a -> Parser a
 trim p = wsc *> p <* wsc
 
@@ -104,4 +101,4 @@ form = do p <- sourcePos
           return $ Form o (Just p) m
 
 program :: Parser [Form]
-program = trim $ wscSep form
+program = trim $ sepBy form mwsc

--- a/src/hs/Kriek/Reader.hs
+++ b/src/hs/Kriek/Reader.hs
@@ -81,13 +81,13 @@ kTuple = ATuple <$> kListy ('[',']')
 
 kMeta :: Parser Meta
 kMeta = do _ <- string "^{"
-           ris <- wscSep kRecItem
+           ris <- sepBy kRecItem ws
            _ <- char '}'
            return ris
 
 kRecItem :: Parser RecItem
 kRecItem = do f1 <- form
-              _ <- skipSome space
+              _ <- some ws
               f2 <- form
               return (f1,f2)
 
@@ -99,8 +99,8 @@ kAst = kQSym <|> kList <|> kTuple <|> kString <|> kKeyword <|> kChar <|> kNil <|
 
 form :: Parser Form
 form = do p <- sourcePos
-          m <- optional kMeta
-          o <- kAst <* wsc
+          m <- optional kMeta <* many ws
+          o <- kAst
           return $ Form o (Just p) m
 
 program :: Parser [Form]


### PR DESCRIPTION
`(def ^{:a 1} b 3)` works just fine now. 

In another PR I want to do some further refactoring and fix how we deal with whitespace. For example, `(def <loads-of-spaces>  ^{:a 1} b 3)` works fine, but `(def ^{:a 1} b 3   )` does not.